### PR TITLE
Create Dockerfile and docker compose files to dockerize and deploy th…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "cSpell.words": [
     "bootcamp",
     "bootcamps",
+    "devcamper",
     "dsphere",
     "Geocoder",
     "mapquest",

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+docker-compose.yml
+.git
+.gitignore
+_postman
+tests
+eslint.config.js
+README.md
+coverage

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,9 +1,11 @@
+# Add .env file in the root of the api folder if you are running in development mode, otherwise add the following environment variables in your server.
+
 # Server configuration
 PORT=6000
-NODE_ENV=production
+NODE_ENV=development
 
 # Database configuration
-MONGO_URI=mongodb://localhost:27017/mern-bootcamp-prod-db
+MONGO_URI=mongodb://localhost:27017/devcamper-db
 
 # Geocoder configuration
 GEOCODER_PROVIDER=mapquest
@@ -29,4 +31,3 @@ FROM_NAME=<YOUR_NAME>
 # Rate limiting configuration
 RATE_LIMIT_WINDOW=10
 RATE_LIMIT_MAX=100
-

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,20 @@
+# Use the official Node.js image as the base image
+FROM node:20
+
+# Set the working directory inside the container
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json to the working directory
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code to the working directory
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Define the command to run the application
+CMD ["npm", "start"]

--- a/api/README.md
+++ b/api/README.md
@@ -1,7 +1,134 @@
-# MERN Bootcamp API
+# DevCamper API
 
-## Description
+## Overview
 
-This is the API for the MERN Bootcamp project. It is a RESTful API that provides endpoints for the MERN Bootcamp project.
+The DevCamper API is a backend service for managing bootcamp-related data, including courses, reviews, and user authentication. This documentation provides detailed instructions for setting up the API in both local and production environments.
 
-<!-- TODO: Add documentation -->
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+  - [Setup Geocoding Service](#setup-geocoding-service)
+  - [Setup SMTP Service (Local Setup)](#setup-smtp-service)
+  - [Setup Postman](#setup-postman)
+- [Local Setup](#local-setup)
+  - [Install NodeJs](#install-nodejs)
+  - [Install MongoDB](#install-mongodb)
+  - [Setup Environment Variables](#setup-environment-variables)
+  - [Seed the Database](#seed-the-database)
+  - [Validate the Data in MongoDB Compass](#validate-the-data-in-mongodb-compass)
+  - [Running the API](#running-the-api)
+  - [Cleanup the Database](#cleanup-the-database)
+
+## Prerequisites
+
+Before setting up the DevCamper API, you need to sign up for the following services and obtain the necessary API keys and credentials. You would also need to install Postman client for testing.
+
+### Setup Geocoding Service
+
+1. Sign up for a free account on [MapQuest](https://developer.mapquest.com/).
+2. Create a new application to get an API key.
+
+### Setup SMTP Service
+
+1. Sign up for a free account on [Mailtrap](https://mailtrap.io/).
+2. Create a new inbox to get SMTP credentials.
+
+### Setup Postman
+
+1. Download and install [Postman](https://www.postman.com/downloads/).
+2. Import the Postman collection provided in the `postman` directory.
+
+## Local Setup
+
+### Install NodeJs
+
+1. Download and install Node.js from the [official website](https://nodejs.org/).
+
+### Install MongoDB
+
+1. Install MongoDB in local environment using one of the following options:
+
+   - [MongoDB Community Server](https://www.mongodb.com/try/download/community)
+   - [Docker](https://docs.docker.com/get-docker/)
+
+     - Run the following command to start a MongoDB container:
+
+       ```bash
+       docker run -d -p 27017:27017 --name devcamper-mongo mongo
+       ```
+
+2. Download and install [MongoDB Compass](https://www.mongodb.com/try/download/compass) for a graphical user interface to interact with the database.
+3. Connect to the MongoDB server using the following connection string:
+
+   ```plaintext
+   mongodb://localhost:27017
+   ```
+
+4. Create a new database named `devcamper-db`.
+
+### Setup Environment Variables
+
+Create a `.env` file in the root of your project directory and configure the following environment variables. Replace the placeholder values with your own credentials and API keys obtained from earlier steps.
+
+```plaintext
+PORT=6000
+NODE_ENV=development
+MONGO_URI=mongodb://localhost:27017/devcamper-db
+GEOCODER_PROVIDER=mapquest
+GEOCODER_API_KEY=your_mapquest_api_key
+FILE_UPLOAD_PATH=./public/uploads
+MAX_FILE_UPLOAD=1000000
+JWT_SECRET=your_jwt_secret
+JWT_EXPIRE=30d
+JWT_COOKIE_EXPIRE=30
+SMTP_HOST=your_smtp_host
+SMTP_PORT=your_smtp_port
+SMTP_EMAIL=your_smtp_email
+SMTP_PASSWORD=your_smtp_password
+FROM_EMAIL=your_from_email
+FROM_NAME=your_from_name
+RATE_LIMIT_MAX=100
+RATE_LIMIT_WINDOW_MS=60000
+```
+
+### Seed the Database
+
+Run the following command to seed the database with bootcamps, courses, and users.
+
+```bash
+node run data:import
+```
+
+### Validate the Data in MongoDB Compass
+
+1. Open MongoDB Compass and connect
+2. Select the `devcamper-db` database
+3. Verify that the `bootcamps`, `courses`, and `users` collections have been created and populated with data.
+
+### Running the API
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Start the API server:
+
+   ```bash
+    npm run dev
+   ```
+
+3. Use the Postman collection provided in the `postman` directory to interact with the API.
+
+4. Make sure that the environment is set to development in Postman.
+
+5. Test the API endpoints to verify that the API is working as expected.
+
+### Cleanup the Database
+
+Run the following command to delete all data from the database. This will remove all bootcamps, courses, and users.
+
+```bash
+node run data:delete
+```

--- a/api/config/env.js
+++ b/api/config/env.js
@@ -2,18 +2,15 @@ import dotenv from 'dotenv';
 
 const loadEnvironmentConfig = () => {
   process.env.NODE_ENV = process.env.NODE_ENV || 'development';
-  switch (process.env.NODE_ENV) {
-    case 'development':
-      dotenv.config();
-      break;
-    case 'test':
-      dotenv.config({ path: '.env.test' });
-      break;
-    case 'production':
-      dotenv.config({ path: '.env.production' });
-      break;
-    default:
-      throw new Error('Environment not recognized');
+
+  // Load environment variables from .env file only in development mode
+  if (process.env.NODE_ENV === 'development') {
+    dotenv.config();
+  }
+
+  // For test and production, assume environment variables are passed directly
+  if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'production') {
+    console.log(`Running in ${process.env.NODE_ENV} mode`);
   }
 };
 

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.8'
+
+services:
+  api:
+    image: prasadhonrao/devcamper-api:latest
+    ports:
+      - '${PORT}:${PORT}'
+    environment:
+      - PORT=${PORT}
+      - NODE_ENV=${NODE_ENV}
+      - MONGO_URI=${MONGO_URI}
+      - GEOCODER_PROVIDER=${GEOCODER_PROVIDER}
+      - GEOCODER_API_KEY=${GEOCODER_API_KEY}
+      - FILE_UPLOAD_PATH=${FILE_UPLOAD_PATH}
+      - MAX_FILE_UPLOAD=${MAX_FILE_UPLOAD}
+      - JWT_SECRET=${JWT_SECRET}
+      - JWT_EXPIRE=${JWT_EXPIRE}
+      - JWT_COOKIE_EXPIRE=${JWT_COOKIE_EXPIRE}
+      - SMTP_HOST=${SMTP_HOST}
+      - SMTP_PORT=${SMTP_PORT}
+      - SMTP_EMAIL=${SMTP_EMAIL}
+      - SMTP_PASSWORD=${SMTP_PASSWORD}
+      - FROM_EMAIL=${FROM_EMAIL}
+      - FROM_NAME=${FROM_NAME}
+      - RATE_LIMIT_MAX=${RATE_LIMIT_MAX}
+      - RATE_LIMIT_WINDOW_MS=${RATE_LIMIT_WINDOW_MS}
+    depends_on:
+      - mongo
+
+  mongo:
+    image: mongo:latest
+    ports:
+      - '27017:27017'
+    volumes:
+      - mongo-data:/data/db
+
+volumes:
+  mongo-data:

--- a/api/utils/geocoder.js
+++ b/api/utils/geocoder.js
@@ -3,7 +3,7 @@ import NodeGeocoder from 'node-geocoder';
 const options = {
   provider: 'mapquest',
   httpAdapter: 'https',
-  apiKey: '', // Add your own API key here
+  apiKey: process.env.GEOCODER_API_KEY,
   formatter: null,
 };
 


### PR DESCRIPTION
This pull request includes several significant changes to the `api` project, focusing on environment configuration, Docker setup, and documentation updates. The most important changes include renaming and modifying the environment configuration file, adding a Dockerfile and docker-compose setup, and updating the README documentation to reflect the new project name and setup instructions.

### Environment Configuration:

* [`api/.env.example`](diffhunk://#diff-2fdd31c8eaeb05db626d15ffa6f31b34be3044212e22d6831e976afbab90cc86R1-R8): Renamed from `api/.env.production` and updated to reflect development mode settings and new database URI.

### Docker Setup:

* [`api/.dockerignore`](diffhunk://#diff-378572971045a124a9ed97c06bb4cfbb988080d97b48d7066f78c9b7c135fc9cR1-R12): Added to specify files and directories to be ignored by Docker.
* [`api/Dockerfile`](diffhunk://#diff-21ee93e31c9cec7a5f33b680622da377c451b62b6c44eac6d9550eade41beb47R1-R20): Created to define the Docker image for the API, including the base image, working directory, dependencies installation, and startup command.
* [`api/docker-compose.yml`](diffhunk://#diff-5def6ff22282af44a83faceb738d68f79f6ab218cf279f9ef94c833be8046be1R1-R38): Added to configure multi-container Docker applications, including the API and MongoDB services.

### Documentation Updates:

* [`api/README.md`](diffhunk://#diff-c7b1c23e00a1fd0378f6ea41a7dfe1c9e043d766f738dba26860c783b82e8c6aL1-R134): Updated to rename the project to "DevCamper API" and added detailed setup instructions for local and production environments.

### Code Updates:

* [`api/config/env.js`](diffhunk://#diff-fcd222ae3e9833d2b3eee24329aaca7b8dcc3e0d357389222ba2930bb2ce5b05L5-R13): Modified to load environment variables from the `.env` file only in development mode and log the environment mode for test and production.
* [`api/utils/geocoder.js`](diffhunk://#diff-7a833d15dcc3741cd84a9a6c5a33788ccb9945693ca7814b15cf6c452ca24e3fL6-R6): Updated to use the `GEOCODER_API_KEY` from environment variables.

Closes #13 